### PR TITLE
Stacey/golang-alpine-kafka: librdkafka breaking version upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # golang-alpine-bash
+
 Golang:Alpine based image with useful things on it
 
 **To Update This Image**
@@ -6,11 +7,19 @@ Golang:Alpine based image with useful things on it
 1. Get Latest Golang container `docker pull golang:alpine`
 2. Add something to the changelog
 3. Commit that change
-4. Build: `docker build -t gcr.io/axiomzen-registry/golang-alpine-bash:latest -t gcr.io/axiomzen-registry/golang-alpine-bash:$(git rev-parse --short HEAD) .` 
+4. Build: `docker build -t gcr.io/axiomzen-registry/golang-alpine-bash:latest -t gcr.io/axiomzen-registry/golang-alpine-bash:$(git rev-parse --short HEAD) .`
 5. Push: `docker push gcr.io/axiomzen-registry/golang-alpine-bash:latest && docker push gcr.io/axiomzen-registry/golang-alpine-bash:$(git rev-parse --short HEAD)`
 
 **Kafka**
 
 - kafka.Dockerfile builds ontop of golang-alpine-bash.
-- Build: `docker build -t gcr.io/axiomzen-registry/golang-alpine-kafka:latest -t gcr.io/axiomzen-registry/golang-alpine-kafka:$(git rev-parse --short HEAD) .` 
+- Build: `docker build -t gcr.io/axiomzen-registry/golang-alpine-kafka:latest -t gcr.io/axiomzen-registry/golang-alpine-kafka:$(git rev-parse --short HEAD) .`
 - Push: `docker push gcr.io/axiomzen-registry/golang-alpine-kafka:latest && docker push gcr.io/axiomzen-registry/golang-alpine-kafka:$(git rev-parse --short HEAD)`
+
+**Kafka Beta**
+Uses librdkafka version 1.0.1 which has update considerations upgrading from
+version used in golang-alpine-kafka image: see [release notes](https://github.com/edenhill/librdkafka/releases/tag/v1.0.0)
+
+- kafka.beta.Dockerfile builds ontop of golang-alpine-bash
+- Build `docker build --file kafka.beta.Dockerfile -t gcr.io/axiomzen-registry/golang-alpine-kafka-beta:latest -t gcr.io/axiomzen-registry/golang-alpine-kafka-beta:$(git rev-parse --short HEAD) .`
+- Push: `docker push gcr.io/axiomzen-registry/golang-alpine-kafka-beta:latest && docker push gcr.io/axiomzen-registry/golang-alpine-kafka-beta:$(git rev-parse --short HEAD)`

--- a/kafka.Dockerfile
+++ b/kafka.Dockerfile
@@ -1,6 +1,6 @@
-from gcr.io/axiomzen-registry/golang-alpine-bash:latest
+FROM gcr.io/axiomzen-registry/golang-alpine-bash:latest
 
-ARG LIBRDKAFKA_VERSION=0.11.6-r1
+ARG LIBRDKAFKA_VERSION=1.0.0
 
 RUN apk add --update --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main openssl && \
     apk add librdkafka-dev=${LIBRDKAFKA_VERSION} --update-cache --repository http://nl.alpinelinux.org/alpine/edge/community

--- a/kafka.beta.Dockerfile
+++ b/kafka.beta.Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/axiomzen-registry/golang-alpine-bash:latest
 
-ARG LIBRDKAFKA_VERSION=0.11.6-r1
+ARG LIBRDKAFKA_VERSION=1.0.1-r1
 
 RUN apk add --update --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main openssl && \
     apk add librdkafka-dev=${LIBRDKAFKA_VERSION} --update-cache --repository http://nl.alpinelinux.org/alpine/edge/community


### PR DESCRIPTION
- Update librdkafka version to support confluent-kafka-go

```
go version go1.11.4 linux/amd64
# github.com/dapperlabs/ck-go-api/vendor/github.com/confluentinc/confluent-kafka-go/kafka
../vendor/github.com/confluentinc/confluent-kafka-go/kafka/00version.go:44:2: error: #error "confluent-kafka-go requires librdkafka v1.0.0 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html"
 #error "confluent-kafka-go requires librdkafka v1.0.0 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html"
```

- Used to create new docker image `gcr.io/axiomzen-registry/golang-alpine-kafka-beta:latest`
- [ ] Need to push this image to registry (missing permissions)