### PR TITLE
add openssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM golang:alpine
-RUN apk --update --no-cache add tar gcc bash musl-dev ca-certificates git && rm -rf /var/cache/apk/*
+RUN apk --update --no-cache add tar gcc bash musl-dev ca-certificates git openssh && rm -rf /var/cache/apk/*
 RUN go get -u github.com/go-bindata/go-bindata/...
 RUN go get -u golang.org/x/tools/cmd/stringer


### PR DESCRIPTION
OpenSSH is often needed if the build image is to build a golang project that has private dependencies (a private git repo).