### PR TITLE
Pin go version to 1.16.7 and add linux headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
-RUN apk --update --no-cache add tar gcc bash musl-dev ca-certificates git openssh && rm -rf /var/cache/apk/*
+FROM golang:1.16-alpine
+RUN apk --update --no-cache add tar gcc bash musl-dev ca-certificates git openssh linux-headers && rm -rf /var/cache/apk/*
 RUN go get -u github.com/go-bindata/go-bindata/...
 RUN go get -u golang.org/x/tools/cmd/stringer


### PR DESCRIPTION
We need to update our base image on Dapper ETH as I am trying to update it to go module. I think it is better if we have a version pinned so that we do not accidentally upgrade to a version that the project might not be ready for.

I've also had to add linux headers as newer version of geth requires it.

Planning to push it to the registry as follows: `gcr.io/axiomzen-registry/golang-alpine-bash:1.16.7`